### PR TITLE
UI feedback: hero contrast, resources layout, navbar, /pets CTA, password meter

### DIFF
--- a/src/app/reset-password/page.tsx
+++ b/src/app/reset-password/page.tsx
@@ -226,16 +226,18 @@ function ResetPasswordContent() {
           value=""
         />
 
-        <PasswordInput
-          label="New password"
-          autoComplete="new-password"
-          placeholder="At least 10 characters"
-          icon={KeyRound}
-          required
-          {...form.register("password")}
-          error={form.formState.errors.password?.message}
-        />
-        <PasswordStrength value={watchedPw ?? ""} />
+        <div className="space-y-2">
+          <PasswordInput
+            label="New password"
+            autoComplete="new-password"
+            placeholder="At least 10 characters"
+            icon={KeyRound}
+            required
+            {...form.register("password")}
+            error={form.formState.errors.password?.message}
+          />
+          <PasswordStrength value={watchedPw ?? ""} />
+        </div>
         <PasswordInput
           label="Confirm new password"
           autoComplete="new-password"

--- a/src/app/reset-password/page.tsx
+++ b/src/app/reset-password/page.tsx
@@ -9,6 +9,7 @@ import { CheckCircle2, KeyRound, ShieldAlert } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components";
 import PasswordInput from "@/components/ui/PasswordInput";
+import PasswordStrength from "@/components/ui/PasswordStrength";
 import AuthLayout from "@/components/layouts/AuthLayout";
 import { ROUTES } from "@/lib/routes";
 import { useAuth } from "@/lib/auth/AuthProvider";
@@ -234,6 +235,7 @@ function ResetPasswordContent() {
           {...form.register("password")}
           error={form.formState.errors.password?.message}
         />
+        <PasswordStrength value={watchedPw ?? ""} />
         <PasswordInput
           label="Confirm new password"
           autoComplete="new-password"

--- a/src/app/reset-password/page.tsx
+++ b/src/app/reset-password/page.tsx
@@ -226,18 +226,16 @@ function ResetPasswordContent() {
           value=""
         />
 
-        <div className="space-y-2">
-          <PasswordInput
-            label="New password"
-            autoComplete="new-password"
-            placeholder="At least 10 characters"
-            icon={KeyRound}
-            required
-            {...form.register("password")}
-            error={form.formState.errors.password?.message}
-          />
-          <PasswordStrength value={watchedPw ?? ""} />
-        </div>
+        <PasswordInput
+          label="New password"
+          autoComplete="new-password"
+          placeholder="At least 10 characters"
+          icon={KeyRound}
+          required
+          {...form.register("password")}
+          error={form.formState.errors.password?.message}
+          footer={<PasswordStrength value={watchedPw ?? ""} />}
+        />
         <PasswordInput
           label="Confirm new password"
           autoComplete="new-password"

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -3,12 +3,13 @@
 import { useEffect, useRef } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { useForm } from "react-hook-form";
+import { useForm, useWatch } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Mail, User as UserIcon } from "lucide-react";
 import { toast } from "sonner";
 import { Button, Input } from "@/components";
 import PasswordInput from "@/components/ui/PasswordInput";
+import PasswordStrength from "@/components/ui/PasswordStrength";
 import GoogleSignInButton from "@/components/ui/GoogleSignInButton";
 import AuthLayout from "@/components/layouts/AuthLayout";
 import { ROUTES, postAuthRedirect } from "@/lib/routes";
@@ -50,6 +51,9 @@ export default function SignupPage() {
     resolver: zodResolver(signupSchema),
     defaultValues: { name: "", email: "", password: "", confirmPassword: "" },
   });
+
+  // Live strength feedback for the password field.
+  const passwordValue = useWatch({ control: form.control, name: "password" });
 
   const onSubmit = async (values: SignupValues) => {
     try {
@@ -138,6 +142,7 @@ export default function SignupPage() {
           {...form.register("password")}
           error={form.formState.errors.password?.message}
         />
+        <PasswordStrength value={passwordValue ?? ""} />
         <PasswordInput
           label="Confirm password"
           autoComplete="new-password"

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -133,18 +133,16 @@ export default function SignupPage() {
           {...form.register("email")}
           error={form.formState.errors.email?.message}
         />
-        <div className="space-y-2">
-          <PasswordInput
-            label="Password"
-            autoComplete="new-password"
-            placeholder="At least 8 characters"
-            hint="Mix letters, numbers, and a symbol for a stronger password."
-            required
-            {...form.register("password")}
-            error={form.formState.errors.password?.message}
-          />
-          <PasswordStrength value={passwordValue ?? ""} />
-        </div>
+        <PasswordInput
+          label="Password"
+          autoComplete="new-password"
+          placeholder="At least 8 characters"
+          hint="Mix letters, numbers, and a symbol for a stronger password."
+          required
+          {...form.register("password")}
+          error={form.formState.errors.password?.message}
+          footer={<PasswordStrength value={passwordValue ?? ""} />}
+        />
         <PasswordInput
           label="Confirm password"
           autoComplete="new-password"

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -133,16 +133,18 @@ export default function SignupPage() {
           {...form.register("email")}
           error={form.formState.errors.email?.message}
         />
-        <PasswordInput
-          label="Password"
-          autoComplete="new-password"
-          placeholder="At least 8 characters"
-          hint="Mix letters, numbers, and a symbol for a stronger password."
-          required
-          {...form.register("password")}
-          error={form.formState.errors.password?.message}
-        />
-        <PasswordStrength value={passwordValue ?? ""} />
+        <div className="space-y-2">
+          <PasswordInput
+            label="Password"
+            autoComplete="new-password"
+            placeholder="At least 8 characters"
+            hint="Mix letters, numbers, and a symbol for a stronger password."
+            required
+            {...form.register("password")}
+            error={form.formState.errors.password?.message}
+          />
+          <PasswordStrength value={passwordValue ?? ""} />
+        </div>
         <PasswordInput
           label="Confirm password"
           autoComplete="new-password"

--- a/src/components/sections/FinalCTASection.tsx
+++ b/src/components/sections/FinalCTASection.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import { usePathname } from "next/navigation";
 import { Heart, PawPrint } from "lucide-react";
 import Button from "../ui/Button";
 import ScrollReveal from "../ui/ScrollReveal";
@@ -10,6 +11,10 @@ import { useAuth } from "@/lib/auth/AuthProvider";
 const FinalCTASection: React.FC = () => {
   const { status } = useAuth();
   const authed = status === "authed";
+  // On /pets the "Browse pets" CTA would link to the current page (a no-op),
+  // so drop it there and let the primary action stand on its own.
+  const pathname = usePathname();
+  const onPetsPage = pathname === ROUTES.pets;
 
   return (
     <section className="animate-gradient relative overflow-hidden bg-gradient-to-br from-pink-500 via-purple-500 to-indigo-500 py-20 sm:py-28">
@@ -45,15 +50,17 @@ const FinalCTASection: React.FC = () => {
                     List a pet
                   </Button>
                 </Link>
-                <Link href={ROUTES.pets} className="w-full sm:w-auto">
-                  <Button
-                    variant="ghost"
-                    size="lg"
-                    className="w-full bg-white/10 text-white hover:bg-white/20 sm:w-auto sm:min-w-[200px]"
-                  >
-                    Browse pets
-                  </Button>
-                </Link>
+                {!onPetsPage && (
+                  <Link href={ROUTES.pets} className="w-full sm:w-auto">
+                    <Button
+                      variant="ghost"
+                      size="lg"
+                      className="w-full bg-white/10 text-white hover:bg-white/20 sm:w-auto sm:min-w-[200px]"
+                    >
+                      Browse pets
+                    </Button>
+                  </Link>
+                )}
               </>
             ) : (
               <>
@@ -67,15 +74,17 @@ const FinalCTASection: React.FC = () => {
                     Join Pet Pod
                   </Button>
                 </Link>
-                <Link href={ROUTES.pets} className="w-full sm:w-auto">
-                  <Button
-                    variant="ghost"
-                    size="lg"
-                    className="w-full bg-white/10 text-white hover:bg-white/20 sm:w-auto sm:min-w-[200px]"
-                  >
-                    Browse pets first
-                  </Button>
-                </Link>
+                {!onPetsPage && (
+                  <Link href={ROUTES.pets} className="w-full sm:w-auto">
+                    <Button
+                      variant="ghost"
+                      size="lg"
+                      className="w-full bg-white/10 text-white hover:bg-white/20 sm:w-auto sm:min-w-[200px]"
+                    >
+                      Browse pets first
+                    </Button>
+                  </Link>
+                )}
               </>
             )}
           </div>

--- a/src/components/sections/HeroSection.tsx
+++ b/src/components/sections/HeroSection.tsx
@@ -131,6 +131,18 @@ const HeroSection: React.FC = () => {
         aria-hidden
       />
 
+      {/*
+        Editorial (calm) and poster (bold) anchor text to the left, where the
+        vertical overlay is lightest — a left-to-right scrim keeps that column
+        legible over bright photos without darkening the whole image.
+      */}
+      {(editorial || poster) && (
+        <div
+          aria-hidden
+          className="absolute inset-0 z-10 bg-gradient-to-r from-black/65 via-black/20 to-transparent"
+        />
+      )}
+
       {tokens.flourish && (
         <div className="absolute inset-0 z-10 overflow-hidden" aria-hidden>
           {flourishes.map(({ Icon, className, delay }, i) => (
@@ -245,7 +257,7 @@ const HeroSection: React.FC = () => {
 
           <motion.p
             variants={words}
-            className="mt-6 max-w-2xl text-base text-white/85 sm:text-lg md:text-xl"
+            className="mt-6 max-w-2xl text-base text-white [text-shadow:0_1px_14px_rgba(0,0,0,0.55)] sm:text-lg md:text-xl"
           >
             Pet Pod connects people who can&apos;t keep their pets with people
             who can. No marketplace, no fees — just honest conversations and

--- a/src/components/sections/ResourcesSection.tsx
+++ b/src/components/sections/ResourcesSection.tsx
@@ -194,19 +194,17 @@ const AudienceBlock: React.FC<AudienceBlockProps> = ({
     return (
       <div className={className}>
         <ScrollReveal>
-          <div className="flex flex-col items-start gap-3 sm:flex-row sm:items-center">
-            <div className="inline-flex h-12 w-12 items-center justify-center rounded-2xl bg-gradient-to-br from-pink-500 to-purple-600 text-white shadow-[0_0_16px_rgba(217,70,239,0.6)]">
+          <div className="flex items-center gap-3">
+            <div className="inline-flex h-12 w-12 shrink-0 items-center justify-center rounded-2xl bg-gradient-to-br from-pink-500 to-purple-600 text-white shadow-[0_0_16px_rgba(217,70,239,0.6)]">
               <Icon className="h-5 w-5" aria-hidden />
             </div>
-            <div>
-              <p className="font-mono text-xs uppercase tracking-[0.3em] text-cyan-300">
-                {`// ${meta.eyebrow.toLowerCase()}`}
-              </p>
-              <p className="mt-1 max-w-2xl text-sm leading-relaxed text-gray-400 sm:text-base">
-                {meta.subtitle}
-              </p>
-            </div>
+            <p className="font-mono text-xs uppercase tracking-[0.3em] text-cyan-300">
+              {`// ${meta.eyebrow.toLowerCase()}`}
+            </p>
           </div>
+          <p className="mt-3 max-w-2xl text-sm leading-relaxed text-gray-400 sm:text-base">
+            {meta.subtitle}
+          </p>
         </ScrollReveal>
 
         <div className="mt-10 grid grid-cols-1 gap-8 md:grid-cols-2 lg:grid-cols-3">
@@ -235,19 +233,17 @@ const AudienceBlock: React.FC<AudienceBlockProps> = ({
   return (
     <div className={className}>
       <ScrollReveal>
-        <div className="flex flex-col items-start gap-3 sm:flex-row sm:items-center">
-          <div className="inline-flex h-12 w-12 items-center justify-center rounded-2xl bg-gradient-to-br from-pink-500 to-purple-600 text-white shadow-md">
+        <div className="flex items-center gap-3">
+          <div className="inline-flex h-12 w-12 shrink-0 items-center justify-center rounded-2xl bg-gradient-to-br from-pink-500 to-purple-600 text-white shadow-md">
             <Icon className="h-5 w-5" aria-hidden />
           </div>
-          <div>
-            <p className="text-xs font-semibold uppercase tracking-wider text-pink-600">
-              {meta.eyebrow}
-            </p>
-            <p className="mt-1 max-w-2xl text-sm leading-relaxed text-gray-600 sm:text-base">
-              {meta.subtitle}
-            </p>
-          </div>
+          <p className="text-xs font-semibold uppercase tracking-wider text-pink-600">
+            {meta.eyebrow}
+          </p>
         </div>
+        <p className="mt-3 max-w-2xl text-sm leading-relaxed text-gray-600 sm:text-base">
+          {meta.subtitle}
+        </p>
       </ScrollReveal>
 
       <div

--- a/src/components/ui/FloatingNavbar.tsx
+++ b/src/components/ui/FloatingNavbar.tsx
@@ -47,21 +47,24 @@ interface FloatingNavbarProps {
   className?: string;
 }
 
-// Scrolled-state surface per vibe. `bg-gray-950/90` carries an opacity suffix
-// the global bold layer doesn't remap, so the scrolled bar would stay a stark
-// near-black slab in every vibe. Playful keeps that (its current look); calm
-// swaps to a light frosted editorial bar with a hairline so it doesn't fight
-// the paper aesthetic; bold keeps the dark slab but adds a neon underline glow.
+// Scrolled-state surface per vibe. Each is a frosted bar pinned to the top.
+// Playful and calm both go light so the bar sits cleanly over the soft page
+// palette instead of dropping a stark near-black slab over pastel content;
+// playful keeps a pink hairline + brand accents, calm a stone hairline. Bold
+// stays a dark slab with a neon underline glow to match its electric-night
+// identity. (The per-vibe strings only ever apply under their own vibe, so
+// the brand-hue borders here aren't subject to the other layers' remaps.)
 const SCROLLED_SURFACE: Record<MotionVibe, string> = {
-  playful: "bg-gray-950/90 top-0 left-0 right-0 py-3 backdrop-blur-md",
+  playful:
+    "bg-white/85 border-b border-pink-100 shadow-sm top-0 left-0 right-0 py-3 backdrop-blur-md",
   calm: "bg-white/90 border-b border-stone-200 top-0 left-0 right-0 py-3 backdrop-blur-md",
   bold: "bg-gray-950/90 border-b border-fuchsia-500/40 shadow-[0_6px_24px_-8px_rgba(217,70,239,0.45)] top-0 left-0 right-0 py-3 backdrop-blur-md",
 };
 
-// Whether the scrolled bar reads as light (dark ink) for that vibe — only calm
-// flips to a light surface, so its links use the light-state ink.
+// Whether the scrolled bar reads as light (dark ink) for that vibe. Playful and
+// calm are light surfaces; only bold keeps a dark slab.
 const SCROLLED_IS_LIGHT: Record<MotionVibe, boolean> = {
-  playful: false,
+  playful: true,
   calm: true,
   bold: false,
 };
@@ -218,7 +221,7 @@ const FloatingNavbar: React.FC<FloatingNavbarProps> = ({ className }) => {
           isMobileMenuOpen ? "max-h-[520px]" : "max-h-0",
         )}
       >
-        <div className="space-y-1 px-3 pb-4 pt-2">
+        <div className="space-y-1 border-t border-black/5 px-3 pb-4 pt-3">
           {navItems.map((item) => (
             <Link
               key={item.name}

--- a/src/components/ui/Input.tsx
+++ b/src/components/ui/Input.tsx
@@ -48,6 +48,9 @@ interface InputProps extends Omit<
   hint?: string;
   icon?: LucideIcon;
   rightSlot?: React.ReactNode;
+  /** Rendered inside the field border, docked below the input row (e.g. a
+   * strength meter) so it reads as one unit with the field. */
+  footer?: React.ReactNode;
   containerClassName?: string;
   /** Show "x / maxLength" counter beside the label. Requires `maxLength` to be set. */
   showCount?: boolean;
@@ -60,6 +63,7 @@ const Input = forwardRef<HTMLInputElement, InputProps>(function Input(
     hint,
     icon: Icon,
     rightSlot,
+    footer,
     className,
     containerClassName,
     required,
@@ -130,30 +134,38 @@ const Input = forwardRef<HTMLInputElement, InputProps>(function Input(
       )}
       <div
         className={cn(
-          "flex items-center gap-2 rounded-xl border-2 bg-white px-3 transition-all",
+          "rounded-xl border-2 bg-white transition-all",
           FIELD_CHROME[vibe].focus,
           error
             ? "border-red-400"
             : cn("border-gray-200", FIELD_CHROME[vibe].hover),
           rest.disabled && "cursor-not-allowed opacity-60",
+          footer && "overflow-hidden",
         )}
       >
-        {Icon && (
-          <Icon className="h-4 w-4 shrink-0 text-gray-400" aria-hidden />
-        )}
-        <input
-          ref={setRef}
-          id={inputId}
-          required={required}
-          maxLength={maxLength}
-          onChange={handleChange}
-          className={cn(
-            "w-full bg-transparent py-2.5 text-sm text-gray-900 placeholder:text-gray-400 focus:outline-none",
-            className,
+        <div className="flex items-center gap-2 px-3">
+          {Icon && (
+            <Icon className="h-4 w-4 shrink-0 text-gray-400" aria-hidden />
           )}
-          {...rest}
-        />
-        {rightSlot && <div className="shrink-0">{rightSlot}</div>}
+          <input
+            ref={setRef}
+            id={inputId}
+            required={required}
+            maxLength={maxLength}
+            onChange={handleChange}
+            className={cn(
+              "w-full bg-transparent py-2.5 text-sm text-gray-900 placeholder:text-gray-400 focus:outline-none",
+              className,
+            )}
+            {...rest}
+          />
+          {rightSlot && <div className="shrink-0">{rightSlot}</div>}
+        </div>
+        {footer && (
+          <div className="border-t border-gray-200/80 bg-gray-50 px-3 py-2.5">
+            {footer}
+          </div>
+        )}
       </div>
       {error ? (
         <p className="text-xs text-red-500">{error}</p>

--- a/src/components/ui/PasswordStrength.tsx
+++ b/src/components/ui/PasswordStrength.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { useMotionVibe } from "@/lib/motion";
+import { cn } from "@/utils";
+
+export type PasswordStrengthLevel = 0 | 1 | 2 | 3;
+
+/**
+ * Bucket a password into three tiers. Points are awarded for length and
+ * character-class variety, then collapsed into Weak / Strong / Very strong so
+ * the meter reads as three segments (red → yellow → green). Returns 0 for an
+ * empty password so callers can hide the meter until the user starts typing.
+ */
+export function scorePasswordStrength(password: string): PasswordStrengthLevel {
+  if (!password) return 0;
+  let points = 0;
+  if (password.length >= 8) points++;
+  if (password.length >= 12) points++;
+  if (/[a-z]/.test(password) && /[A-Z]/.test(password)) points++;
+  if (/\d/.test(password)) points++;
+  if (/[^A-Za-z0-9]/.test(password)) points++;
+  if (points <= 2) return 1;
+  if (points <= 3) return 2;
+  return 3;
+}
+
+const LEVEL_META: Record<1 | 2 | 3, { label: string; bar: string }> = {
+  1: { label: "Weak", bar: "bg-red-500" },
+  2: { label: "Strong", bar: "bg-yellow-400" },
+  3: { label: "Very strong", bar: "bg-green-500" },
+};
+
+// The meter sits on the auth form card, which is light in playful/calm and
+// dark in bold — so the label ink and the empty-track colour flip for bold.
+const LABEL_INK: Record<"light" | "dark", Record<1 | 2 | 3, string>> = {
+  light: { 1: "text-red-600", 2: "text-yellow-600", 3: "text-green-600" },
+  dark: { 1: "text-red-400", 2: "text-yellow-300", 3: "text-green-400" },
+};
+
+interface PasswordStrengthProps {
+  value: string;
+  className?: string;
+}
+
+const PasswordStrength: React.FC<PasswordStrengthProps> = ({
+  value,
+  className,
+}) => {
+  const { vibe } = useMotionVibe();
+  const level = scorePasswordStrength(value);
+
+  // Nothing to show until the user starts typing.
+  if (level === 0) return null;
+
+  const surface = vibe === "bold" ? "dark" : "light";
+  const track = surface === "dark" ? "bg-white/15" : "bg-gray-200";
+  const meta = LEVEL_META[level];
+
+  return (
+    <div className={cn("space-y-1.5", className)} aria-live="polite">
+      <div className="flex gap-1.5">
+        {([1, 2, 3] as const).map((segment) => (
+          <span
+            key={segment}
+            className={cn(
+              "h-1.5 flex-1 rounded-full transition-colors duration-300",
+              segment <= level ? meta.bar : track,
+            )}
+          />
+        ))}
+      </div>
+      <p className={cn("text-xs font-medium", LABEL_INK[surface][level])}>
+        Password strength: {meta.label}
+      </p>
+    </div>
+  );
+};
+
+export default PasswordStrength;

--- a/src/components/ui/PasswordStrength.tsx
+++ b/src/components/ui/PasswordStrength.tsx
@@ -11,9 +11,8 @@ const SEGMENTS = 5;
  * Bucket a password into five tiers (Very weak → Very strong). One point each
  * for reaching 8 and 12 characters, mixing upper- and lower-case, including a
  * digit, and including a symbol; the 0–5 total maps to a tier (0 and 1 both
- * read as "very weak"). The five-segment meter nudges people toward the top of
- * the scale. Returns 0 for an empty password so callers can hide the meter
- * until typing starts.
+ * read as "very weak"). Returns 0 only for an empty password, which the meter
+ * renders as an idle grey track.
  */
 export function scorePasswordStrength(password: string): PasswordStrengthLevel {
   if (!password) return 0;
@@ -34,8 +33,8 @@ const LEVEL_META: Record<1 | 2 | 3 | 4 | 5, { label: string; bar: string }> = {
   5: { label: "Very strong", bar: "bg-green-600" },
 };
 
-// The meter sits on the auth form card, which is light in playful/calm and
-// dark in bold — so the label ink and empty-track colour flip for bold.
+// The meter sits inside the auth input, which is light in playful/calm and
+// dark in bold — so the label ink and idle-track colour flip for bold.
 const LABEL_INK: Record<"light" | "dark", Record<1 | 2 | 3 | 4 | 5, string>> = {
   light: {
     1: "text-red-600",
@@ -65,16 +64,17 @@ const PasswordStrength: React.FC<PasswordStrengthProps> = ({
   const { vibe } = useMotionVibe();
   const level = scorePasswordStrength(value);
 
-  // Nothing to show until the user starts typing.
-  if (level === 0) return null;
-
   const surface = vibe === "bold" ? "dark" : "light";
-  const track = surface === "dark" ? "bg-white/15" : "bg-gray-200";
-  const meta = LEVEL_META[level];
+  const track = surface === "dark" ? "bg-white/20" : "bg-gray-300/70";
+
+  // Narrows level away from 0 in the else branches so the 1–5 maps type-check.
+  const activeBar = level === 0 ? null : LEVEL_META[level].bar;
+  const label = level === 0 ? "Password strength" : LEVEL_META[level].label;
+  const labelInk = level === 0 ? "text-gray-400" : LABEL_INK[surface][level];
 
   return (
     <div
-      className={cn("flex items-center gap-2", className)}
+      className={cn("flex items-center justify-between gap-3", className)}
       aria-live="polite"
     >
       <div className="flex gap-1">
@@ -83,14 +83,12 @@ const PasswordStrength: React.FC<PasswordStrengthProps> = ({
             key={segment}
             className={cn(
               "h-1.5 w-6 rounded-full transition-colors duration-300",
-              segment <= level ? meta.bar : track,
+              activeBar && segment <= level ? activeBar : track,
             )}
           />
         ))}
       </div>
-      <span className={cn("text-xs font-medium", LABEL_INK[surface][level])}>
-        {meta.label}
-      </span>
+      <span className={cn("text-xs font-medium", labelInk)}>{label}</span>
     </div>
   );
 };

--- a/src/components/ui/PasswordStrength.tsx
+++ b/src/components/ui/PasswordStrength.tsx
@@ -3,13 +3,17 @@
 import { useMotionVibe } from "@/lib/motion";
 import { cn } from "@/utils";
 
-export type PasswordStrengthLevel = 0 | 1 | 2 | 3;
+export type PasswordStrengthLevel = 0 | 1 | 2 | 3 | 4 | 5;
+
+const SEGMENTS = 5;
 
 /**
- * Bucket a password into three tiers. Points are awarded for length and
- * character-class variety, then collapsed into Weak / Strong / Very strong so
- * the meter reads as three segments (red → yellow → green). Returns 0 for an
- * empty password so callers can hide the meter until the user starts typing.
+ * Bucket a password into five tiers (Very weak → Very strong). One point each
+ * for reaching 8 and 12 characters, mixing upper- and lower-case, including a
+ * digit, and including a symbol; the 0–5 total maps to a tier (0 and 1 both
+ * read as "very weak"). The five-segment meter nudges people toward the top of
+ * the scale. Returns 0 for an empty password so callers can hide the meter
+ * until typing starts.
  */
 export function scorePasswordStrength(password: string): PasswordStrengthLevel {
   if (!password) return 0;
@@ -19,22 +23,34 @@ export function scorePasswordStrength(password: string): PasswordStrengthLevel {
   if (/[a-z]/.test(password) && /[A-Z]/.test(password)) points++;
   if (/\d/.test(password)) points++;
   if (/[^A-Za-z0-9]/.test(password)) points++;
-  if (points <= 2) return 1;
-  if (points <= 3) return 2;
-  return 3;
+  return Math.max(1, points) as PasswordStrengthLevel;
 }
 
-const LEVEL_META: Record<1 | 2 | 3, { label: string; bar: string }> = {
-  1: { label: "Weak", bar: "bg-red-500" },
-  2: { label: "Strong", bar: "bg-yellow-400" },
-  3: { label: "Very strong", bar: "bg-green-500" },
+const LEVEL_META: Record<1 | 2 | 3 | 4 | 5, { label: string; bar: string }> = {
+  1: { label: "Very weak", bar: "bg-red-500" },
+  2: { label: "Weak", bar: "bg-orange-500" },
+  3: { label: "Medium", bar: "bg-yellow-400" },
+  4: { label: "Strong", bar: "bg-lime-500" },
+  5: { label: "Very strong", bar: "bg-green-600" },
 };
 
 // The meter sits on the auth form card, which is light in playful/calm and
-// dark in bold — so the label ink and the empty-track colour flip for bold.
-const LABEL_INK: Record<"light" | "dark", Record<1 | 2 | 3, string>> = {
-  light: { 1: "text-red-600", 2: "text-yellow-600", 3: "text-green-600" },
-  dark: { 1: "text-red-400", 2: "text-yellow-300", 3: "text-green-400" },
+// dark in bold — so the label ink and empty-track colour flip for bold.
+const LABEL_INK: Record<"light" | "dark", Record<1 | 2 | 3 | 4 | 5, string>> = {
+  light: {
+    1: "text-red-600",
+    2: "text-orange-600",
+    3: "text-yellow-600",
+    4: "text-lime-600",
+    5: "text-green-600",
+  },
+  dark: {
+    1: "text-red-400",
+    2: "text-orange-400",
+    3: "text-yellow-300",
+    4: "text-lime-300",
+    5: "text-green-400",
+  },
 };
 
 interface PasswordStrengthProps {
@@ -57,21 +73,24 @@ const PasswordStrength: React.FC<PasswordStrengthProps> = ({
   const meta = LEVEL_META[level];
 
   return (
-    <div className={cn("space-y-1.5", className)} aria-live="polite">
-      <div className="flex gap-1.5">
-        {([1, 2, 3] as const).map((segment) => (
+    <div
+      className={cn("flex items-center gap-2", className)}
+      aria-live="polite"
+    >
+      <div className="flex gap-1">
+        {Array.from({ length: SEGMENTS }, (_, i) => i + 1).map((segment) => (
           <span
             key={segment}
             className={cn(
-              "h-1.5 flex-1 rounded-full transition-colors duration-300",
+              "h-1.5 w-6 rounded-full transition-colors duration-300",
               segment <= level ? meta.bar : track,
             )}
           />
         ))}
       </div>
-      <p className={cn("text-xs font-medium", LABEL_INK[surface][level])}>
-        Password strength: {meta.label}
-      </p>
+      <span className={cn("text-xs font-medium", LABEL_INK[surface][level])}>
+        {meta.label}
+      </span>
     </div>
   );
 };

--- a/src/components/ui/PasswordStrength.tsx
+++ b/src/components/ui/PasswordStrength.tsx
@@ -2,28 +2,9 @@
 
 import { useMotionVibe } from "@/lib/motion";
 import { cn } from "@/utils";
-
-export type PasswordStrengthLevel = 0 | 1 | 2 | 3 | 4 | 5;
+import { scorePasswordStrength } from "@/lib/validation/password";
 
 const SEGMENTS = 5;
-
-/**
- * Bucket a password into five tiers (Very weak → Very strong). One point each
- * for reaching 8 and 12 characters, mixing upper- and lower-case, including a
- * digit, and including a symbol; the 0–5 total maps to a tier (0 and 1 both
- * read as "very weak"). Returns 0 only for an empty password, which the meter
- * renders as an idle grey track.
- */
-export function scorePasswordStrength(password: string): PasswordStrengthLevel {
-  if (!password) return 0;
-  let points = 0;
-  if (password.length >= 8) points++;
-  if (password.length >= 12) points++;
-  if (/[a-z]/.test(password) && /[A-Z]/.test(password)) points++;
-  if (/\d/.test(password)) points++;
-  if (/[^A-Za-z0-9]/.test(password)) points++;
-  return Math.max(1, points) as PasswordStrengthLevel;
-}
 
 const LEVEL_META: Record<1 | 2 | 3 | 4 | 5, { label: string; bar: string }> = {
   1: { label: "Very weak", bar: "bg-red-500" },

--- a/src/lib/validation/auth.ts
+++ b/src/lib/validation/auth.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { isPasswordStrongEnough } from "./password";
 
 export const loginSchema = z.object({
   email: z.string().min(1, "Email is required").email("Invalid email"),
@@ -16,7 +17,11 @@ export const signupSchema = z
     password: z
       .string()
       .min(8, "Password must be at least 8 characters")
-      .max(100, "Password is too long"),
+      .max(100, "Password is too long")
+      .refine(
+        isPasswordStrongEnough,
+        "Too weak — aim for at least Medium strength.",
+      ),
     confirmPassword: z.string().min(1, "Please confirm your password"),
   })
   .refine((data) => data.password === data.confirmPassword, {
@@ -35,7 +40,11 @@ export const resetPasswordSchema = z
     password: z
       .string()
       .min(10, "Password must be at least 10 characters")
-      .max(100, "Password is too long"),
+      .max(100, "Password is too long")
+      .refine(
+        isPasswordStrongEnough,
+        "Too weak — aim for at least Medium strength.",
+      ),
     confirmPassword: z.string().min(1, "Please confirm your password"),
   })
   .refine((data) => data.password === data.confirmPassword, {

--- a/src/lib/validation/password.ts
+++ b/src/lib/validation/password.ts
@@ -1,0 +1,30 @@
+// Pure password-strength scoring, shared by the zod schemas (must stay
+// framework-free so validation can run anywhere) and the PasswordStrength meter
+// (client). No React / motion imports here on purpose.
+
+export type PasswordStrengthLevel = 0 | 1 | 2 | 3 | 4 | 5;
+
+/**
+ * Bucket a password into five tiers (1 Very weak → 5 Very strong). One point
+ * each for reaching 8 and 12 characters, mixing upper- and lower-case,
+ * including a digit, and including a symbol; the 0–5 total maps to a tier (0
+ * and 1 both read as "very weak"). Returns 0 only for an empty password.
+ */
+export function scorePasswordStrength(password: string): PasswordStrengthLevel {
+  if (!password) return 0;
+  let points = 0;
+  if (password.length >= 8) points++;
+  if (password.length >= 12) points++;
+  if (/[a-z]/.test(password) && /[A-Z]/.test(password)) points++;
+  if (/\d/.test(password)) points++;
+  if (/[^A-Za-z0-9]/.test(password)) points++;
+  return Math.max(1, points) as PasswordStrengthLevel;
+}
+
+/** Minimum tier accepted at submit — "Medium" (3). */
+export const MIN_PASSWORD_STRENGTH: PasswordStrengthLevel = 3;
+
+/** Whether a password clears the minimum accepted tier. */
+export function isPasswordStrongEnough(password: string): boolean {
+  return scorePasswordStrength(password) >= MIN_PASSWORD_STRENGTH;
+}


### PR DESCRIPTION
Round of friend-feedback fixes across the themed UI.

| # | Feedback | Fix |
|---|---|---|
| 1 | Calm hero body copy not readable over the photo | Left-to-right scrim for the calm/bold left-anchored layouts + paragraph bumped to full white with a text-shadow (image-agnostic) |
| 2 | Resources cards: awkward icon/eyebrow stacking ("icon then header") | Default + bold audience blocks now read icon → header inline, subtitle drops below |
| 3 | Navbar scrolled bg + menu bg "not a perfect combination" | Playful scrolled surface: near-black slab → on-brand light frosted bar (pink hairline); menu inherits it; subtle menu divider added |
| 4 | "Browse pets first" does nothing on /pets | `FinalCTASection` is now route-aware — the browse button is hidden on /pets (it linked to the current page) |
| 5 | Want a password-strength indicator | New vibe-aware `PasswordStrength` meter (3 segments, red/yellow/green → Weak/Strong/Very strong) on signup + reset-password |

**Scope:** frontend only, additive. Themes touched: calm/bold (hero), all (resources default+bold, navbar playful, password meter). `npm run lint` clean, `npm run build` green.

**Note on the navbar:** the screenshots pointed at "header background when scrolling" + "header menu background" — I read that as the playful scrolled bar (a stark near-black slab over the pastel page) and made it a light frosted bar. If the intent was actually the purple `FinalCTA` band in the shot, easy follow-up.